### PR TITLE
Use a variable for proxy_pass to force DNS resolution at request-time instead of during startup

### DIFF
--- a/example/default.conf
+++ b/example/default.conf
@@ -17,7 +17,9 @@ server {
 		# let the proxied server handle whether this "body" is too large
 		client_max_body_size 0;
 
-		proxy_pass http://wordpress-example.docker;
+		# use a variable so NGINX is forced to resolve this at request time instead of at startup
+		set $proxy_to http://wordpress-example.docker;
+		proxy_pass $proxy_to;
 		include conf.d/proxy-pass.include;
 	}
 }
@@ -50,7 +52,9 @@ server {
 		# let the proxied server handle whether this "body" is too large
 		client_max_body_size 0;
 
-		proxy_pass https://bugzilla-example.docker;
+		# use a variable so NGINX is forced to resolve this at request time instead of at startup
+		set $proxy_to https://bugzilla-example.docker;
+		proxy_pass $proxy_to;
 		include conf.d/proxy-pass.include;
 	}
 }
@@ -125,7 +129,9 @@ server {
 		# let the proxied server handle whether this "body" is too large
 		client_max_body_size 0;
 
-		proxy_pass http://some-external-host.corp.example.com;
+		# use a variable so NGINX is forced to resolve this at request time instead of at startup
+		set $proxy_to http://some-external-host.corp.example.com;
+		proxy_pass $proxy_to;
 		include conf.d/proxy-pass.include;
 	}
 }

--- a/generate.sh
+++ b/generate.sh
@@ -120,7 +120,9 @@ EOB
 		# let the proxied server handle whether this "body" is too large
 		client_max_body_size 0;
 
-		proxy_pass $proxyTo;
+		# use a variable so NGINX is forced to resolve this at request time instead of at startup
+		set \$proxy_to $proxyTo;
+		proxy_pass \$proxy_to;
 		include conf.d/proxy-pass.include;
 EOB
 	fi


### PR DESCRIPTION
According to https://sandro-keil.de/blog/2017/07/24/let-nginx-start-if-upstream-host-is-unavailable-or-down/, this closes #1. :man_facepalming: